### PR TITLE
fix types path for users

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.0",
   "main": "dist/index.js",
   "module": "dist/index.cjs",
-  "types": "src/index.d.ts",
+  "types": "dist/index.d.ts",
   "author": "MelonCode",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
the types path was not working for users, just for authors.

my current workaround is adding this to my tsconfig.json:
```
  "compilerOptions": {
...
    "paths": {
      "react-tweakpane": ["./node_modules/react-tweakpane/dist/index.d.ts"]
    }
  },
  ```