### PR TITLE
some updates to hooks

### DIFF
--- a/src/hooks/useListBlade.ts
+++ b/src/hooks/useListBlade.ts
@@ -12,7 +12,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import { ListApi } from 'tweakpane'
+import { ListBladeApi } from 'tweakpane'
 import { PaneInstance } from './useTweakpane'
 
 interface UseSliderBladeParams<T> extends BaseBladeParams {
@@ -25,13 +25,13 @@ interface UseSliderBladeParams<T> extends BaseBladeParams {
 export function useListBlade<T extends Object, V>(
   paneRef: MutableRefObject<PaneInstance<T>>,
   bladeParams: UseSliderBladeParams<V>
-): [V, (value: V) => void, MutableRefObject<ListApi<V>>]
+): [V, (value: V) => void, MutableRefObject<ListBladeApi<V>>]
 
 export function useListBlade<T extends Object, V>(
   paneRef: MutableRefObject<PaneInstance<T>>,
   bladeParams: UseSliderBladeParams<V>,
   onChange: (event: TpChangeEvent<V>) => void
-): [never, (value: V) => void, MutableRefObject<ListApi<V>>]
+): [never, (value: V) => void, MutableRefObject<ListBladeApi<V>>]
 
 export function useListBlade<T extends Object, V>(
   paneRef: MutableRefObject<PaneInstance<T>>,
@@ -40,7 +40,7 @@ export function useListBlade<T extends Object, V>(
 ) {
   const [value, set] = useState<V>(params.value)
 
-  const bladeRef = useRef<ListApi<V>>(null!)
+  const bladeRef = useRef<ListBladeApi<V>>(null!)
 
   const callbackRef = useRef(onChange)
   callbackRef.current = onChange
@@ -74,7 +74,7 @@ export function useListBlade<T extends Object, V>(
     if (pane == null) return
 
     params.view = params.view || 'list'
-    const blade = pane.addBlade(params) as ListApi<V>
+    const blade = pane.addBlade(params) as ListBladeApi<V>
 
     blade.on('change', handler)
     bladeRef.current = blade

--- a/src/hooks/usePaneInput.ts
+++ b/src/hooks/usePaneInput.ts
@@ -1,4 +1,4 @@
-import { InputBindingApi, InputParams, TpChangeEvent } from '@tweakpane/core'
+import { InputBindingApi, BindingParams, TpChangeEvent } from '@tweakpane/core'
 
 import {
   RefObject,
@@ -17,11 +17,11 @@ type InputRef<T> = RefObject<InputBindingApi<unknown, T>>
 export function usePaneInput<T extends Object, K extends keyof T>(
   ref: RefObject<FolderInstance<T>>,
   key: K,
-  inputParams: InputParams | undefined,
+  BindingParams: BindingParams | undefined,
   onChange: (event: TpChangeEvent<T[K]>) => void
 ): [never, (value: T[K]) => void, InputRef<T[K]>]
 
-// Skips inputParams
+// Skips BindingParams
 /** Does not return the value and doesn't trigger an update because onChange is specified */
 export function usePaneInput<T extends Object, K extends keyof T>(
   paneRef: RefObject<FolderInstance<T>>,
@@ -35,14 +35,14 @@ export function usePaneInput<T extends Object, K extends keyof T>(
 export function usePaneInput<T extends Object, K extends keyof T>(
   paneRef: RefObject<FolderInstance<T>>,
   key: K,
-  inputParams?: InputParams | undefined,
+  BindingParams?: BindingParams | undefined,
   onChange?: undefined
 ): [T[K], (value: T[K]) => void, InputRef<T[K]>]
 
 export function usePaneInput<T extends Object, K extends keyof T>(
   paneRef: RefObject<FolderInstance<T>>,
   key: K,
-  inputParams?: InputParams | undefined,
+  BindingParams?: BindingParams | undefined,
   onChange?: undefined
 ): [T[K], (value: T[K]) => void, InputRef<T[K]>]
 
@@ -50,12 +50,12 @@ export function usePaneInput<T extends Object, K extends keyof T>(
   parentRef: RefObject<FolderInstance<T>>,
   key: K,
   inputParamsArg:
-    | InputParams
+    | BindingParams
     | ((event: TpChangeEvent<T[K]>) => void)
     | undefined = {},
   onChangeArg: ((event: TpChangeEvent<T[K]>) => void) | undefined = undefined
 ) {
-  const inputParams = typeof inputParamsArg === 'function' ? {} : inputParamsArg
+  const BindingParams = typeof inputParamsArg === 'function' ? {} : inputParamsArg
   const onChange =
     typeof inputParamsArg === 'function' ? inputParamsArg : onChangeArg
 
@@ -67,13 +67,14 @@ export function usePaneInput<T extends Object, K extends keyof T>(
   callbackRef.current = onChange
 
   const setValue = useCallback((value: T[K]) => {
-    inputRef.current.controller_.binding.target.write(value)
+    // inputRef.current.controller_.binding.target.write(value)
+    inputRef.current.controller.value.binding.write(value)
     inputRef.current.refresh()
   }, [])
 
   if (inputRef.current) {
-    inputRef.current.hidden = Boolean(inputParams.hidden)
-    inputRef.current.disabled = Boolean(inputParams.disabled)
+    inputRef.current.hidden = Boolean(BindingParams.hidden)
+    inputRef.current.disabled = Boolean(BindingParams.disabled)
   }
 
   useLayoutEffect(() => {
@@ -85,11 +86,11 @@ export function usePaneInput<T extends Object, K extends keyof T>(
       : (event) => set(event.value)
 
     const input = pane
-      .addInput(parentRef.current!.params, key, inputParams)
+      .addBinding(parentRef.current!.params, key, BindingParams)
       .on('change', handler)
-
+      
     inputRef.current = input
-
+    // inputRef.current.controller.importState.arguments = input
     return () => {
       if (input.element) input.dispose()
     }

--- a/src/hooks/useSliderBlade.ts
+++ b/src/hooks/useSliderBlade.ts
@@ -7,7 +7,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import { SliderApi } from 'tweakpane'
+import { SliderBladeApi } from 'tweakpane'
 import { FolderInstance } from './usePaneFolder'
 
 interface UseSliderBladeParams extends BaseBladeParams {
@@ -19,7 +19,7 @@ interface UseSliderBladeParams extends BaseBladeParams {
   value?: number
 }
 
-type BladeRef = MutableRefObject<SliderApi>
+type BladeRef = MutableRefObject<SliderBladeApi>
 
 export function useSliderBlade<T extends Object, V>(
   paneRef: MutableRefObject<FolderInstance<T>>,
@@ -39,7 +39,7 @@ export function useSliderBlade<T extends Object>(
 ) {
   const [value, set] = useState<number>(params.value || 0)
 
-  const bladeRef = useRef<SliderApi>(null!)
+  const bladeRef = useRef<SliderBladeApi>(null!)
 
   const callbackRef = useRef(onChange)
   callbackRef.current = onChange
@@ -50,8 +50,8 @@ export function useSliderBlade<T extends Object>(
     blade.disabled = Boolean(params.disabled)
     blade.hidden = Boolean(params.hidden)
     blade.label = params.label
-    blade.maxValue = params.max
-    blade.minValue = params.min
+    blade.max = params.max
+    blade.min = params.min
     blade.value = params.value || 0
   }, [
     params.disabled,
@@ -71,7 +71,7 @@ export function useSliderBlade<T extends Object>(
     if (pane == null) return
 
     params.view = params.view || 'slider'
-    const blade = pane.addBlade(params) as SliderApi
+    const blade = pane.addBlade(params) as SliderBladeApi
 
     const handler: (ev: TpChangeEvent<number>) => void = onChange
       ? (event) => callbackRef.current!(event)

--- a/src/hooks/useTextBlade.ts
+++ b/src/hooks/useTextBlade.ts
@@ -6,7 +6,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import { BaseBladeParams, TextApi, TpChangeEvent } from 'tweakpane'
+import { BaseBladeParams, TextBladeApi, TpChangeEvent } from 'tweakpane'
 import { FolderInstance } from './usePaneFolder'
 
 interface UseTextBladeParams<T> extends BaseBladeParams {
@@ -16,7 +16,7 @@ interface UseTextBladeParams<T> extends BaseBladeParams {
   label?: string
 }
 
-type BladeRef<V> = MutableRefObject<TextApi<V>>
+type BladeRef<V> = MutableRefObject<TextBladeApi<V>>
 
 export function useTextBlade<T extends Object, V>(
   paneRef: MutableRefObject<FolderInstance<T>>,
@@ -36,7 +36,7 @@ export function useTextBlade<T extends Object, V>(
 ) {
   const [value, set] = useState<V>(params.value)
 
-  const bladeRef = useRef<TextApi<V>>(null!)
+  const bladeRef = useRef<TextBladeApi<V>>(null!)
 
   const callbackRef = useRef(onChange)
   callbackRef.current = onChange
@@ -60,7 +60,7 @@ export function useTextBlade<T extends Object, V>(
     if (pane == null) return
 
     params.view = params.view || 'text'
-    const blade = pane.addBlade(params) as TextApi<V>
+    const blade = pane.addBlade(params) as TextBladeApi<V>
 
     const handler: (ev: TpChangeEvent<V>) => void = onChange
       ? (event) => callbackRef.current!(event)


### PR DESCRIPTION
This is a great project and with a lot of potential. Hopefully it continues to evolve. I tried to update as many things as possible, however, there are two things that really got me.

1. https://github.com/MelonCode/react-tweakpane/blob/25258dc70cba02b5375335ce70c8793d898dd6d0/src/hooks/usePaneInput.ts#L70
```
// inputRef.current.controller_.binding.target.write(value) // not longer works
inputRef.current.controller.value.binding.write(value) // proposed solution?
```

and 

2. https://github.com/MelonCode/react-tweakpane/blob/25258dc70cba02b5375335ce70c8793d898dd6d0/src/hooks/usePaneInput.ts#L91

```
inputRef.current = input
```
is not longer valid. Not sure on how to move forward here.

Also, updated dependencies are also missing in this PR.  

